### PR TITLE
annotations: add show_annotations input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -57,3 +57,7 @@ inputs:
   config:
     description: "path to configuration file (json, yaml or toml)"
     required: false
+  show_annotations:
+    description: "show github annotations on pull requests"
+    required: false
+    default: "true"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -101,8 +101,11 @@ function validate_flags() {
 }
 
 annotate() {
+  if [ "${INPUT_SHOW_ANNOTATIONS}" == "false" ]; then
+    exit "${ORCA_EXIT_CODE}"
+  fi
   mkdir -p "/app/${OUTPUT_FOR_JSON}"
-  cp  "${OUTPUT_FOR_JSON}/iac.json" "/app/${OUTPUT_FOR_JSON}/"
+  cp "${OUTPUT_FOR_JSON}/iac.json" "/app/${OUTPUT_FOR_JSON}/"
   cd /app || exit_with_err "error during annotations initiation"
   npm run build --if-present
   node dist/index.js


### PR DESCRIPTION
'true' by default
pull request annotations can be disabled by setting 'show_annotations' to 'false'