### PR TITLE
feat: add the skip_scan_log variable to disable uploading reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ jobs:
 | display_name             | custom-display-name                        | Scan log display name (on Orca platform)                                                                | String  | No       | N/A                           |
 | debug                    | true                                       | Debug mode                                                                                              | Boolean | No       | false                         |
 | log_path                 | results/                                   | The directory path to specify where the logs should be written to on debug mode.                        | String  | No       | working directory             |
+| skip_scan_log            | true                                       | Disable persistence of the scan log results in Orca's backend (and show only CLI results)               | Boolean | No       | false                         |
 
 ## Annotations
 

--- a/action.yaml
+++ b/action.yaml
@@ -104,6 +104,10 @@ inputs:
   log_path:
     description: "The directory path to specify where the logs should be written to on debug mode. Default to the current working directory"
     required: false
+  skip_scan_log:
+    description: "Disable persistence of the scan log results in Orca's backend (and show only CLI results)"
+    required: false
+    default: "false"
 
 outputs:
   exit_code:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -132,6 +132,9 @@ function set_iac_scan_flags() {
   if [ "${INPUT_TERRAFORM_VARS_PATH}" ]; then
     SCAN_FLAGS+=(--terraform-vars-path "${INPUT_TERRAFORM_VARS_PATH}")
   fi
+  if [ "${INPUT_SKIP_SCAN_LOG}" ]; then
+    SCAN_FLAGS+=(--skip-scan-log "${INPUT_SKIP_SCAN_LOG}")
+  fi
 }
 
 function set_env_vars() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,6 +47,9 @@ function set_global_flags() {
   if [ "${INPUT_LOG_PATH}" ]; then
     GLOBAL_FLAGS+=(--log-path "${INPUT_LOG_PATH}")
   fi
+  if [ "${INPUT_SKIP_SCAN_LOG}" ]; then
+    GLOBAL_FLAGS+=(--skip-scan-log)
+  fi
 }
 
 # Json format must be reported and be stored in a file for github annotations
@@ -131,9 +134,6 @@ function set_iac_scan_flags() {
   fi
   if [ "${INPUT_TERRAFORM_VARS_PATH}" ]; then
     SCAN_FLAGS+=(--terraform-vars-path "${INPUT_TERRAFORM_VARS_PATH}")
-  fi
-  if [ "${INPUT_SKIP_SCAN_LOG}" ]; then
-    SCAN_FLAGS+=(--skip-scan-log "${INPUT_SKIP_SCAN_LOG}")
   fi
 }
 


### PR DESCRIPTION
Add variable to action and entrypoint to stop results being uploaded to Orca backend.